### PR TITLE
feat: basic stage channel support

### DIFF
--- a/commands/say.js
+++ b/commands/say.js
@@ -98,6 +98,9 @@ module.exports = {
 				});
 				return;
 			}
+			if (interaction.member.voice.channel.type === 'GUILD_STAGE_VOICE' && !interaction.member.voice.channel.stageInstance) {
+				await interaction.member.voice.channel.createStageInstance({ topic: getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'TTS_STAGE_TOPIC'), privacyLevel: 'GUILD_ONLY' });
+			}
 		}
 		if (player.playing) {
 			await interaction.editReply({

--- a/commands/say.js
+++ b/commands/say.js
@@ -85,9 +85,22 @@ module.exports = {
 			player = interaction.client.music.createPlayer(interaction.guildId);
 			player.queue.channel = interaction.channel;
 			await player.connect(interaction.member.voice.channelId, { deafened: true });
-		}
-		if (interaction.member.voice.channel.type === 'GUILD_STAGE_VOICE' && !interaction.member.voice.channel.stageInstance) {
-			await interaction.member.voice.channel.createStageInstance({ topic: getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'TTS_STAGE_TOPIC'), privacyLevel: 'GUILD_ONLY' });
+			// that kid left while we were busy bruh
+			if (!interaction.member.voice.channelId) {
+				player.disconnect();
+				interaction.client.music.destroyPlayer(interaction.guildId);
+				await interaction.editReply({
+					embeds: [
+						new MessageEmbed()
+							.setDescription(getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'DISCORD_INTERACTION_CANCELED', interaction.user.id))
+							.setColor(defaultColor),
+					],
+				});
+				return;
+			}
+			if (interaction.member.voice.channel.type === 'GUILD_STAGE_VOICE' && !interaction.member.voice.channel.stageInstance) {
+				await interaction.member.voice.channel.createStageInstance({ topic: getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'TTS_STAGE_TOPIC'), privacyLevel: 'GUILD_ONLY' });
+			}
 		}
 		if (player.playing) {
 			await interaction.editReply({

--- a/commands/say.js
+++ b/commands/say.js
@@ -98,9 +98,6 @@ module.exports = {
 				});
 				return;
 			}
-			if (interaction.member.voice.channel.type === 'GUILD_STAGE_VOICE' && !interaction.member.voice.channel.stageInstance) {
-				await interaction.member.voice.channel.createStageInstance({ topic: getLocale(guildData.get(`${interaction.guildId}.locale`) ?? defaultLocale, 'TTS_STAGE_TOPIC'), privacyLevel: 'GUILD_ONLY' });
-			}
 		}
 		if (player.playing) {
 			await interaction.editReply({

--- a/locales/en-US.json
+++ b/locales/en-US.json
@@ -22,6 +22,7 @@
   "LOG_GUILD_LEFT": "Left %1",
   "TTS_ALONE": "Disconnected as everyone left.",
   "TTS_INACTIVITY": "Disconnected from inactivity.",
+  "TTS_STAGE_TOPIC": "Text to Speech by Warden",
   "TTS_RESTART": "Warden is restarting and will disconnect.",
   "TTS_RESTART_CRASH": "Warden has crashed and will disconnect.",
   "TTS_RESTART_SORRY": "Sorry for the inconvenience caused.",


### PR DESCRIPTION
Adds stage channel support to `say.js`

Notes
- Doesn't come with voice and stage channel permission checks in `main.js`'s `interactionCreate` event listener since Warden depends on `say.js` alone to play a track if I remember correctly.

Also comes with the following fix for crash: 
- When a user leaves before TTS plays.