### PR TITLE
refactor: use shuttingDown when exiting

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ const rl = readline.createInterface({
 });
 rl.on('line', line => {
 	if (line === 'exit') {
-		process.exit(0);
+		shuttingDown('exit');
 	}
 });
 


### PR DESCRIPTION
While `process.exit(0)` alone is good enough, I think this one is better because this makes Warden to explicitly use the shuttingDown function when exit is called from readline then do its remaining tasks and gracefully exit from there.