### PR TITLE
refactor: include SIGTERM check for TTS_RESTART

### DIFF
--- a/main.js
+++ b/main.js
@@ -231,7 +231,7 @@ async function shuttingDown(eventType, err) {
 			await player.queue.channel.send({
 				embeds: [
 					new MessageEmbed()
-						.setDescription(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, ['exit', 'SIGINT'].includes(eventType) ? 'TTS_RESTART' : 'TTS_RESTART_CRASH')}`)
+						.setDescription(`${getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, ['exit', 'SIGINT', 'SIGTERM'].includes(eventType) ? 'TTS_RESTART' : 'TTS_RESTART_CRASH')}`)
 						.setFooter({ text: getLocale(guildData.get(`${player.guildId}.locale`) ?? defaultLocale, 'TTS_RESTART_SORRY') })
 						.setColor(defaultColor),
 				],


### PR DESCRIPTION
Whenever SIGTERM is called, it uses the TTS_RESTART_CRASH locale, this resolves it, and will instead use TTS_RESTART.