### PR TITLE
feat: add readline SIGINT event listener

### DIFF
--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ rl.on('line', line => {
 		process.exit(0);
 	}
 });
+rl.on('close', () => shuttingDown('SIGINT'));
 
 const bot = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_PRESENCES, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_VOICE_STATES] });
 bot.commands = new Collection();

--- a/main.js
+++ b/main.js
@@ -19,6 +19,7 @@ rl.on('line', line => {
 		process.exit(0);
 	}
 });
+// 'close' event catches ctrl+c, therefore we pass it to shuttingDown as a ctrl+c event
 rl.on('close', () => shuttingDown('SIGINT'));
 
 const bot = new Client({ intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_PRESENCES, Intents.FLAGS.GUILD_MEMBERS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_VOICE_STATES] });


### PR DESCRIPTION
This readline event listener will listen for `SIGINT` (CTRL+C) and `EOT` (CTRL+D) as well.
Added because on some instances, it takes 2 SIGINT signals to terminate the process. Since there is no readline SIGINT event listener, readline treats the 1st SIGINT signal as pausing itself, the 2nd signal being SIGINT forcibly terminating the process.